### PR TITLE
1.9 support + extra features and fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.8.8-R0.1-SNAPSHOT</version>
+            <version>1.9.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- For PRISM API; included locally as not available on repo -->

--- a/src/main/java/se/enji/WoodCutter.java
+++ b/src/main/java/se/enji/WoodCutter.java
@@ -95,21 +95,17 @@ public class WoodCutter extends JavaPlugin implements Listener {
 				if (prism != null) {
 					prism.recordBreak(block, state.player);
 				}
-				block.breakNaturally();
+				block.breakNaturally(state.heldItem);
 				fallen++;
 				state.totalFallen++;
 			}
 			
 			else logsLeft = false;
 
-			columnCheck(state, block, 1.0, 0);
-			columnCheck(state, block, 0, 1.0);
-			columnCheck(state, block, -1.0, 0);
-			columnCheck(state, block, 0, -1.0);
-			columnCheck(state, block, 1.0, 1.0);
-			columnCheck(state, block, 1.0, -1.0);
-			columnCheck(state, block, -1.0, 1.0);
-			columnCheck(state, block, -1.0, -1.0);
+			for (int x = -1; x <= 1; x++)
+			for (int z = -1; z <= 1; z++) {
+				columnCheck(state, block, x, z);
+			}
 		}
 
 		durabilityCheck(state, fallen);

--- a/src/main/java/se/enji/WoodCutter.java
+++ b/src/main/java/se/enji/WoodCutter.java
@@ -60,7 +60,7 @@ public class WoodCutter extends JavaPlugin implements Listener {
 			return;
 		}
 		
-		if (!breakable.contains(e.getBlock().getType()) || !isAxe(p.getItemInHand().getType())) {
+		if (!breakable.contains(e.getBlock().getType()) || !isHoldingAxe(p)) {
 			return;
 		}
 		
@@ -107,13 +107,10 @@ public class WoodCutter extends JavaPlugin implements Listener {
 			columnCheck(state, block, -1.0, 1.0);
 			columnCheck(state, block, -1.0, -1.0);
 		}
-		
-		ItemStack handItem = state.player.getItemInHand();
-		int unbreaking = handItem.getEnchantmentLevel(Enchantment.DURABILITY);
 
-		if (unbreaking > 0) {
+		if (state.heldItemUnbreaking > 0) {
 			// http://minecraft.gamepedia.com/Enchantment#Enchantments
-			int chance = 100 / (unbreaking + 1);
+			int chance = 100 / (state.heldItemUnbreaking + 1);
 			int oldFallen = fallen;
 
 			for (int i = 0; i < oldFallen; i++) {
@@ -121,13 +118,13 @@ public class WoodCutter extends JavaPlugin implements Listener {
 			}
 		}
 		
-		short durability = (short)(state.player.getItemInHand().getDurability() + fallen);
+		short durability = (short)(state.heldItem.getDurability() + fallen);
 
-		if (durability < maxDurability(handItem.getType())) {
-			handItem.setDurability(durability);
+		if (durability < maxDurability(state.heldItem.getType())) {
+			state.heldItem.setDurability(durability);
 		} else {
-			handItem.setAmount(0);
-			state.player.setItemInHand(null);
+			state.heldItem.setAmount(0);
+			state.player.getInventory().setItemInMainHand(null);
 		}
 		
 	}
@@ -147,8 +144,9 @@ public class WoodCutter extends JavaPlugin implements Listener {
 		}
 	}
 
-	private boolean isAxe(Material a) {
-		return !needAxe || a.toString().endsWith("_AXE");
+	private boolean isHoldingAxe(Player p) {
+		Material held = p.getInventory().getItemInMainHand().getType();
+		return !needAxe || held.toString().endsWith("_AXE");
 	}
 	
 	private short maxDurability(Material m) {

--- a/src/main/java/se/enji/WoodCutter.java
+++ b/src/main/java/se/enji/WoodCutter.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
+import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -127,6 +128,10 @@ public class WoodCutter extends JavaPlugin implements Listener {
 	}
 
 	private void durabilityCheck(WoodCutterState state, int fallen) {
+		if (state.player.getGameMode() == GameMode.CREATIVE) {
+			return;
+		}
+		
 		if (!isHoldingAxe(state.player) || state.heldItem.getAmount() == 0) {
 			return;
 		}

--- a/src/main/java/se/enji/WoodCutter.java
+++ b/src/main/java/se/enji/WoodCutter.java
@@ -60,7 +60,11 @@ public class WoodCutter extends JavaPlugin implements Listener {
 			return;
 		}
 		
-		if (!breakable.contains(e.getBlock().getType()) || !isHoldingAxe(p)) {
+		if (!breakable.contains(e.getBlock().getType())) {
+			return;
+		}
+
+		if (needAxe && !isHoldingAxe(p)) {
 			return;
 		}
 		
@@ -108,25 +112,7 @@ public class WoodCutter extends JavaPlugin implements Listener {
 			columnCheck(state, block, -1.0, -1.0);
 		}
 
-		if (state.heldItemUnbreaking > 0) {
-			// http://minecraft.gamepedia.com/Enchantment#Enchantments
-			int chance = 100 / (state.heldItemUnbreaking + 1);
-			int oldFallen = fallen;
-
-			for (int i = 0; i < oldFallen; i++) {
-				if (random.nextInt(100) > chance) fallen--;
-			}
-		}
-		
-		short durability = (short)(state.heldItem.getDurability() + fallen);
-
-		if (durability < maxDurability(state.heldItem.getType())) {
-			state.heldItem.setDurability(durability);
-		} else {
-			state.heldItem.setAmount(0);
-			state.player.getInventory().setItemInMainHand(null);
-		}
-		
+		durabilityCheck(state, fallen);
 	}
 
 	private void columnCheck(WoodCutterState state, Block block, double xOffset, double zOffset) {
@@ -144,9 +130,34 @@ public class WoodCutter extends JavaPlugin implements Listener {
 		}
 	}
 
+	private void durabilityCheck(WoodCutterState state, int fallen) {
+		if (!isHoldingAxe(state.player) || state.heldItem.getAmount() == 0) {
+			return;
+		}
+
+		if (state.heldItemUnbreaking > 0) {
+			// http://minecraft.gamepedia.com/Enchantment#Enchantments
+			int chance = 100 / (state.heldItemUnbreaking + 1);
+			int oldFallen = fallen;
+
+			for (int i = 0; i < oldFallen; i++) {
+				if (random.nextInt(100) > chance) fallen--;
+			}
+		}
+
+		short newDurability = (short)(state.heldItem.getDurability() + fallen);
+
+		if (newDurability < maxDurability(state.heldItem.getType())) {
+			state.heldItem.setDurability(newDurability);
+		} else {
+			state.heldItem.setAmount(0);
+			state.player.getInventory().setItemInMainHand(null);
+		}
+	}
+
 	private boolean isHoldingAxe(Player p) {
 		Material held = p.getInventory().getItemInMainHand().getType();
-		return !needAxe || held.toString().endsWith("_AXE");
+		return held.toString().endsWith("_AXE");
 	}
 	
 	private short maxDurability(Material m) {

--- a/src/main/java/se/enji/WoodCutterState.java
+++ b/src/main/java/se/enji/WoodCutterState.java
@@ -28,6 +28,8 @@ public class WoodCutterState {
 
     @SuppressWarnings("deprecation")
     public boolean isSameTree(Block block) {
+        // Using deprecated ID and meta here, because the only alternative seems to be
+        // creating new Tree objects. Seems too wasteful
         int blockId = block.getTypeId();
         int blockMeta = block.getData();
         

--- a/src/main/java/se/enji/WoodCutterState.java
+++ b/src/main/java/se/enji/WoodCutterState.java
@@ -2,13 +2,17 @@ package se.enji;
 
 import org.bukkit.Location;
 import org.bukkit.block.Block;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 public class WoodCutterState {
     int id;
     byte meta;
     Location origin;
     Player player;
+    ItemStack heldItem;
+    int heldItemUnbreaking;
 
     int totalFallen = 0;
 
@@ -18,6 +22,8 @@ public class WoodCutterState {
         this.meta = block.getData();
         this.origin = block.getLocation();
         this.player = player;
+        this.heldItem = player.getInventory().getItemInMainHand();
+        this.heldItemUnbreaking = heldItem.getEnchantmentLevel(Enchantment.DURABILITY);
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/se/enji/WoodCutterState.java
+++ b/src/main/java/se/enji/WoodCutterState.java
@@ -7,12 +7,12 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 public class WoodCutterState {
-    int id;
-    byte meta;
-    Location origin;
-    Player player;
-    ItemStack heldItem;
-    int heldItemUnbreaking;
+    final int id;
+    final byte meta;
+    final Location origin;
+    final Player player;
+    final ItemStack heldItem;
+    final int heldItemUnbreaking;
 
     int totalFallen = 0;
 


### PR DESCRIPTION
This pull request isn't required for 1.9 support per se; it appears that WoodCutter works just fine in 1.9. These are just some fixes, extra features and changes to avoid using methods deprecated in Bukkit 1.9.
# Changes
- Built against Spigot API 1.9.2
- Replaced all uses of `getItemInHand` with new `getItemInMainHand`
- Fixed a discovered issue where having `needAxe` set to false meant held items would disappear, if used for chopping. Durability damage en-masse now only happens to axes
  - Eventually, this needs to consider other tools like [swords, shovels and pickaxes](http://minecraft.gamepedia.com/Item_durability#Tool_durability)
- Durability damage no longer applies if player is in creative mode
- Blocks now broken with held item taken into account
- Moved some getters into state initialization
- Other minor code reformatting
# Testing
- Tested on local Spigot 1.9.2 server with just EssentialsX - no issues found
- Tested on live beta Spigot 1.9.2 server with many plugins - no issues found
